### PR TITLE
Switches terser import to default syntax

### DIFF
--- a/builds/rollup.config.mjs
+++ b/builds/rollup.config.mjs
@@ -1,17 +1,21 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import { terser } from '@rollup/plugin-terser';
+// ⬇️ use default import (not { terser })
+import terser from '@rollup/plugin-terser';
 
 export default [
   {
-    // Use your existing file as the entry
-    input: 'knackFunctions.js',
+    input: 'knackFunctions.js',               // or 'src/index.js' if you move it later
     output: {
       file: 'dist/knackFunctions.iife.min.js',
       format: 'iife',
       name: 'KnackFns',
       sourcemap: false
     },
-    plugins: [resolve(), commonjs(), terser()]
+    plugins: [
+      resolve(),
+      commonjs(),
+      terser()                                // minify
+    ]
   }
 ];


### PR DESCRIPTION
Uses the default import for terser plugin to align with current
Rollup plugin conventions and ensure compatibility with newer
module systems. Improves maintainability and reduces potential
import errors.