### PR TITLE
updated chagelog entries to be better

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -105,9 +105,10 @@ jobs:
               return lines.slice(start, end);
             }
 
-            function extractNamedSection(body) {
+            function extractSectionByName(body, sectionNames) {
               const lines = stripHtmlComments(body).split('\n');
-              const sectionPattern = /^#{1,6}\s*(changelog|summary|changes)\s*$/i;
+              const escapedNames = sectionNames.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+              const sectionPattern = new RegExp(`^#{1,6}\\s*(${escapedNames.join('|')})\\s*$`, 'i');
 
               for (let index = 0; index < lines.length; index += 1) {
                 if (!sectionPattern.test(lines[index].trim())) {
@@ -131,6 +132,12 @@ jobs:
               return '';
             }
 
+            function extractNamedSection(body) {
+              return extractSectionByName(body, ['Changelog'])
+                || extractSectionByName(body, ['Changes'])
+                || extractSectionByName(body, ['Summary']);
+            }
+
             function toEntries(sectionText) {
               const lines = trimEmptyLines(stripHtmlComments(sectionText).split('\n'));
               const bulletEntries = lines
@@ -150,10 +157,17 @@ jobs:
                 .filter(Boolean);
 
               if (paragraphEntries.length) {
-                return [paragraphEntries[0]];
+                return paragraphEntries;
               }
 
               return [];
+            }
+
+            function sanitiseCommentValue(value) {
+              return String(value || '')
+                .replace(/--/g, '- -')
+                .replace(/>/g, '')
+                .trim();
             }
 
             const { owner, repo } = context.repo;
@@ -179,14 +193,16 @@ jobs:
             const finalEntries = changelogEntries.length
               ? changelogEntries
               : [mergedPullRequest.title.trim()];
-            const authorSuffix = mergedPullRequest.user?.login ? ` (by @${mergedPullRequest.user.login})` : '';
+            const branchName = sanitiseCommentValue(mergedPullRequest.head?.ref || 'unknown-branch');
+            const authorName = sanitiseCommentValue(mergedPullRequest.user?.login || 'unknown-author');
 
-            const marker = `<!-- pr:${mergedPullRequest.number} -->`;
+            const marker = `<!-- pr:${mergedPullRequest.number} ${branchName} - ${authorName} -->`;
+            const existingMarkerPattern = new RegExp(`<!--\\s*pr:${mergedPullRequest.number}\\b[^>]*-->`);
             const dateHeading = `## ${new Date().toISOString().slice(0, 10)}`;
-            const entryBlock = `${marker}\n${finalEntries.map((entry) => `- ${entry}${authorSuffix}`).join('\n')}`;
+            const entryBlock = `${marker}\n${finalEntries.map((entry) => `- ${entry}`).join('\n')}`;
             const existingContent = fs.readFileSync(changelogPath, 'utf8').replace(/\r/g, '');
 
-            if (existingContent.includes(marker)) {
+            if (existingMarkerPattern.test(existingContent)) {
               core.info(`CHANGELOG already includes PR #${mergedPullRequest.number}.`);
               core.setOutput('changed', 'false');
               return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 2026-03-30
 
-<!-- pr:44 -->
-- Added a pull request template with Summary, Changelog, and Testing sections, and updated the merge workflow to copy the reviewed Changelog text from merged PRs into CHANGELOG.md instead of relying on in-branch changelog edits. (by @amandajane-mo)
-
-- MultiFormSubmissionCoordinator now treats Knack's `knack-form-submit` event as a successful auto-form outcome, which prevents false timeouts when a form submits without leaving a persistent success message in the DOM.
-- Kept the existing DOM-based success, error, and invalid-input checks as fallback outcome detection.
-- Added a console fallback for `errorHandler` so apps without a configured handler still log the original error context instead of throwing a `ReferenceError`.
+<!-- pr:44 Fix-build-and-tag - amandajane-mo -->
+- Added a pull request template with Summary, Changelog, and Testing sections, and updated the merge workflow to copy reviewed PR changelog text into `CHANGELOG.md` instead of relying on in-branch changelog edits.
+- Fixed the build-and-tag workflow so generated changelog and dist commits push cleanly to `main`, only falling back to a rebase with autostash if the branch moved underneath the workflow run.
+- Updated interactive tables so column headers can render trusted HTML for custom labels, tooltips, and directional indicators instead of forcing escaped plain text.
+- Documented the shared interactive table helper with usage examples, configuration options, editable rules, date and select behaviour, and auto-append row support.
+- Improved multi-form submission handling so `MultiFormSubmissionCoordinator` treats `knack-form-submit` as the primary success signal, which prevents false timeouts when a form submits successfully without leaving a persistent success message in the DOM.
+- Kept the existing DOM-based success, error, and invalid-input checks as fallback outcome detection for multi-form submission monitoring.
+- Added a fallback global `errorHandler` so apps that do not configure one still log the original error context instead of throwing a secondary `ReferenceError` during form submission failures.
+- Added `fadeFormConfirmation`, which fades and removes Knack form confirmation messages after a configurable delay without requiring extra app-specific CSS.
+- Improved `_rtp` popup redirect handling so modal views can redirect on submit or close, support `_rtp=false` to disable close redirects, and support `scene_1234` exclusions when a specific scene should suppress the redirect.


### PR DESCRIPTION
## Summary

Fix the changelog merge workflow so it uses the intended PR changelog text and handles generated commits more reliably.

Correct the existing changelog entry for PR 44 so it reflects the shipped changes from PRs 43 and 44.

## Changelog

Changelog
Fixed the build-and-tag workflow so generated changelog and dist commits push cleanly to main, only falling back to a rebase with autostash if the branch moved underneath the workflow run.

Updated the changelog workflow to prefer ## Changelog over ## Summary when reading merged PR descriptions.

Fixed changelog parsing so paragraph-style text under ## Changelog is preserved as multiple entries instead of only keeping the first paragraph.

Updated changelog markers to include the PR number, branch name, and author while keeping visible changelog bullets free of repeated author suffixes.

Corrected the PR 44 changelog entry so it captures the full shipped changes from PRs 43 and 44.