### PR TITLE
Add clear button to irt

### DIFF
--- a/Wiki/Interactive Table.md
+++ b/Wiki/Interactive Table.md
@@ -66,6 +66,9 @@ The main options are:
 - `saveMode`: `'manual'`, `'none'`, or `'auto'`
 - `saveButtonText`: label for the manual submit button
 - `saveButtonClassName`: extra classes for the submit button
+- `showClearButton`: render a clear button in the top-right table toolbar
+- `clearButtonText`: label for the clear button
+- `clearButtonClassName`: extra classes for the clear button
 - `autoAppendRow`: keep a blank row at the bottom and append another when the last row becomes populated
 - `createEmptyRow`: optional function that returns the next blank row shape
 - `isRowPopulated`: optional function used to decide when a row counts as populated
@@ -73,6 +76,7 @@ The main options are:
 - `columns`: column definitions
 - `onChange`: callback after a cell value changes
 - `onSubmit`: callback used when manual submit is triggered
+- `onClear`: callback used when the clear button is triggered
 - `onRenderComplete`: callback after the first render
 
 ## Column configuration
@@ -300,6 +304,25 @@ const tableController = renderInteractiveTable({
 ```
 
 Important: the helper does not decide what to save or where to save it. That stays in the consuming app.
+
+## Clear button
+
+When `showClearButton` is enabled, the helper renders the clear action in a small toolbar above the table, aligned to the right-hand side of the header area.
+
+Example:
+
+```javascript
+renderInteractiveTable({
+    viewId: 'view_2214',
+    showClearButton: true,
+    clearButtonText: 'Clear rows',
+    rows,
+    columns,
+    onClear: function ({ data, rawData }) {
+        console.log('Table cleared', { data, rawData });
+    },
+});
+```
 
 ## Where app-specific logic should live
 

--- a/Wiki/Interactive Table.md
+++ b/Wiki/Interactive Table.md
@@ -69,6 +69,8 @@ The main options are:
 - `showClearButton`: render a clear button in the top-right table toolbar
 - `clearButtonText`: label for the clear button
 - `clearButtonClassName`: extra classes for the clear button
+- `confirmOnClear`: whether clearing rows should ask for confirmation first, defaults to `true`
+- `clearConfirmMessage`: custom confirmation text shown before rows are cleared
 - `autoAppendRow`: keep a blank row at the bottom and append another when the last row becomes populated
 - `createEmptyRow`: optional function that returns the next blank row shape
 - `isRowPopulated`: optional function used to decide when a row counts as populated
@@ -316,6 +318,7 @@ renderInteractiveTable({
     viewId: 'view_2214',
     showClearButton: true,
     clearButtonText: 'Clear rows',
+    clearConfirmMessage: 'Are you sure you want to clear all rows from this table? Any unsaved edits will be lost.',
     rows,
     columns,
     onClear: function ({ data, rawData }) {
@@ -323,6 +326,8 @@ renderInteractiveTable({
     },
 });
 ```
+
+Set `confirmOnClear: false` if you want the clear action to run immediately without showing the shared confirmation dialog.
 
 ## Where app-specific logic should live
 

--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -7386,7 +7386,7 @@ function escapeHTML(text) {
  * @param {'none'|'manual'|'auto'} [config.saveMode='manual'] - Save behaviour. `manual` renders a submit button, `auto` is reserved for save-as-you-go flows, `none` disables built-in save UI.
  * @param {string} [config.saveButtonText='Save'] - Text shown on the manual submit button.
  * @param {string} [config.saveButtonClassName=''] - Extra CSS classes appended to the default `kn-button is-primary` button classes.
- * @param {boolean} [config.showClearButton=false] - Whether to render a clear button in the action area.
+ * @param {boolean} [config.showClearButton=false] - Whether to render a clear button in the top-right table toolbar.
  * @param {string} [config.clearButtonText='Clear'] - Text shown on the clear button.
  * @param {string} [config.clearButtonClassName=''] - Extra CSS classes appended to the default `kn-button is-secondary` clear button classes.
  * @param {Function|null} [config.onSubmit=null] - Called when the manual submit button is clicked or controller.submit() is invoked.
@@ -8038,10 +8038,11 @@ function renderInteractiveTable(config = {}) {
             return `<tr data-row-index="${rowIndex}">${cellsHtml}</tr>`;
         }).join('');
 
+        const headerActionsHtml = showClearButton
+            ? `<div class="kfInteractiveTable__toolbar" style="display:flex;justify-content:flex-end;align-items:center;margin-bottom:8px;"><button class="${escapeHTML(clearButtonClass)}" type="button" data-kf-interactive-table-clear="true"${isSubmitting ? ' disabled' : ''}>${escapeHTML(clearButtonText)}</button></div>`
+            : '';
+
         const actionButtons = [
-            showClearButton
-                ? `<button class="${escapeHTML(clearButtonClass)}" type="button" data-kf-interactive-table-clear="true"${isSubmitting ? ' disabled' : ''}>${escapeHTML(clearButtonText)}</button>`
-                : '',
             showSubmitButton
                 ? `<button class="${escapeHTML(submitButtonClass)}" type="submit" data-kf-interactive-table-submit="true"${isSubmitting ? ' disabled' : ''}>${escapeHTML(saveButtonText)}</button>`
                 : '',
@@ -8051,7 +8052,7 @@ function renderInteractiveTable(config = {}) {
             ? `<div class="kfInteractiveTable__actions" style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;">${actionButtons}</div>`
             : '';
 
-        host.innerHTML = `<table class="${escapeHTML(tableClass)}"><thead><tr>${headersHtml}</tr></thead><tbody>${rowsHtml}</tbody></table>${actionsHtml}`;
+        host.innerHTML = `${headerActionsHtml}<table class="${escapeHTML(tableClass)}"><thead><tr>${headersHtml}</tr></thead><tbody>${rowsHtml}</tbody></table>${actionsHtml}`;
     };
 
     const clearTable = async () => {

--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -7386,7 +7386,11 @@ function escapeHTML(text) {
  * @param {'none'|'manual'|'auto'} [config.saveMode='manual'] - Save behaviour. `manual` renders a submit button, `auto` is reserved for save-as-you-go flows, `none` disables built-in save UI.
  * @param {string} [config.saveButtonText='Save'] - Text shown on the manual submit button.
  * @param {string} [config.saveButtonClassName=''] - Extra CSS classes appended to the default `kn-button is-primary` button classes.
+ * @param {boolean} [config.showClearButton=false] - Whether to render a clear button in the action area.
+ * @param {string} [config.clearButtonText='Clear'] - Text shown on the clear button.
+ * @param {string} [config.clearButtonClassName=''] - Extra CSS classes appended to the default `kn-button is-secondary` clear button classes.
  * @param {Function|null} [config.onSubmit=null] - Called when the manual submit button is clicked or controller.submit() is invoked.
+ * @param {Function|null} [config.onClear=null] - Called after the clear button is clicked or controller.clear() is invoked.
  * @param {Array<{header?: string, key?: string|number, type?: string, editable?: boolean|Function, options?: Array|Function, className?: string, inputClassName?: string, align?: string, maxWidth?: string|number|null, allowHtml?: boolean, display?: Function, parse?: Function, openDateHintKey?: string, minDate?: string|Date|null, maxDate?: string|Date|null, dateFormat?: string}>} [config.columns=[]] - Column schema. Select options may be a static array, a function returning an array, or an async function/Promise resolving to an array. `type: 'search-select'` renders a searchable input backed by a datalist while still storing the selected option value. Select options are fetched once per column and cached for the current table instance.
  * @param {Array<string>} [config.headers=[]] - Optional headers when columns are omitted.
  * @param {Array<Object|Array>} [config.rows=[]] - Prefilled row data.
@@ -7403,6 +7407,9 @@ function renderInteractiveTable(config = {}) {
         saveMode: 'manual',
         saveButtonText: 'Save',
         saveButtonClassName: '',
+        showClearButton: false,
+        clearButtonText: 'Clear',
+        clearButtonClassName: '',
         autoAppendRow: false,
         createEmptyRow: null,
         isRowPopulated: null,
@@ -7411,6 +7418,7 @@ function renderInteractiveTable(config = {}) {
         rows: [],
         onChange: null,
         onSubmit: null,
+        onClear: null,
         onRenderComplete: null,
         ...config,
     };
@@ -7993,7 +8001,11 @@ function renderInteractiveTable(config = {}) {
         const showSubmitButton = saveMode === 'manual';
         const saveButtonText = String(settings.saveButtonText || 'Save').trim() || 'Save';
         const saveButtonClassName = String(settings.saveButtonClassName || '').trim();
-        const buttonClass = ['kn-button', 'is-primary', saveButtonClassName].filter(Boolean).join(' ');
+        const submitButtonClass = ['kn-button', 'is-primary', saveButtonClassName].filter(Boolean).join(' ');
+        const showClearButton = settings.showClearButton === true;
+        const clearButtonText = String(settings.clearButtonText || 'Clear').trim() || 'Clear';
+        const clearButtonClassName = String(settings.clearButtonClassName || '').trim();
+        const clearButtonClass = ['kn-button', 'is-secondary', clearButtonClassName].filter(Boolean).join(' ');
 
         const headersHtml = columns.map((column) => {
             const align = String(column.align || 'left');
@@ -8026,11 +8038,43 @@ function renderInteractiveTable(config = {}) {
             return `<tr data-row-index="${rowIndex}">${cellsHtml}</tr>`;
         }).join('');
 
-        const actionsHtml = showSubmitButton
-            ? `<div class="kfInteractiveTable__actions" style="margin-top:12px;"><button class="${escapeHTML(buttonClass)}" type="submit" data-kf-interactive-table-submit="true"${isSubmitting ? ' disabled' : ''}>${escapeHTML(saveButtonText)}</button></div>`
+        const actionButtons = [
+            showClearButton
+                ? `<button class="${escapeHTML(clearButtonClass)}" type="button" data-kf-interactive-table-clear="true"${isSubmitting ? ' disabled' : ''}>${escapeHTML(clearButtonText)}</button>`
+                : '',
+            showSubmitButton
+                ? `<button class="${escapeHTML(submitButtonClass)}" type="submit" data-kf-interactive-table-submit="true"${isSubmitting ? ' disabled' : ''}>${escapeHTML(saveButtonText)}</button>`
+                : '',
+        ].filter(Boolean).join('');
+
+        const actionsHtml = actionButtons
+            ? `<div class="kfInteractiveTable__actions" style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;">${actionButtons}</div>`
             : '';
 
         host.innerHTML = `<table class="${escapeHTML(tableClass)}"><thead><tr>${headersHtml}</tr></thead><tbody>${rowsHtml}</tbody></table>${actionsHtml}`;
+    };
+
+    const clearTable = async () => {
+        if (isSubmitting) return;
+
+        rowsData = [];
+        ensureTrailingEmptyRow();
+        renderTable();
+
+        if (typeof settings.onClear === 'function') {
+            try {
+                await settings.onClear({
+                    viewId,
+                    host,
+                    data: getData(),
+                    rawData: getRawData(),
+                    controller,
+                });
+            } catch (err) {
+                console.error('renderInteractiveTable onClear error:', err);
+                throw err;
+            }
+        }
     };
 
     const submitTable = async () => {
@@ -8460,6 +8504,13 @@ function renderInteractiveTable(config = {}) {
             return;
         }
 
+        const clearButton = event.target.closest('[data-kf-interactive-table-clear="true"]');
+        if (clearButton && host.contains(clearButton)) {
+            event.preventDefault();
+            void clearTable();
+            return;
+        }
+
         const editor = event.target.closest('.kfInteractiveTable__editor');
         if (editor && host.contains(editor)) return;
 
@@ -8471,6 +8522,9 @@ function renderInteractiveTable(config = {}) {
     const handleTableMouseDown = (event) => {
         const submitButton = event.target.closest('[data-kf-interactive-table-submit="true"]');
         if (submitButton && host.contains(submitButton)) return;
+
+        const clearButton = event.target.closest('[data-kf-interactive-table-clear="true"]');
+        if (clearButton && host.contains(clearButton)) return;
 
         const editor = event.target.closest('.kfInteractiveTable__editor');
         if (editor && host.contains(editor)) return;
@@ -8560,6 +8614,9 @@ function renderInteractiveTable(config = {}) {
         },
         async submit() {
             await submitTable();
+        },
+        async clear() {
+            await clearTable();
         },
         destroy() {
             selectOptionsCache.clear();

--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -7389,6 +7389,8 @@ function escapeHTML(text) {
  * @param {boolean} [config.showClearButton=false] - Whether to render a clear button in the top-right table toolbar.
  * @param {string} [config.clearButtonText='Clear'] - Text shown on the clear button.
  * @param {string} [config.clearButtonClassName=''] - Extra CSS classes appended to the default `kn-button is-secondary` clear button classes.
+ * @param {boolean} [config.confirmOnClear=true] - Whether clearing rows should ask for confirmation first.
+ * @param {string} [config.clearConfirmMessage='Are you sure you want to clear all rows? This will remove any unsaved table data.'] - Confirmation text shown before rows are cleared.
  * @param {Function|null} [config.onSubmit=null] - Called when the manual submit button is clicked or controller.submit() is invoked.
  * @param {Function|null} [config.onClear=null] - Called after the clear button is clicked or controller.clear() is invoked.
  * @param {Array<{header?: string, key?: string|number, type?: string, editable?: boolean|Function, options?: Array|Function, className?: string, inputClassName?: string, align?: string, maxWidth?: string|number|null, allowHtml?: boolean, display?: Function, parse?: Function, openDateHintKey?: string, minDate?: string|Date|null, maxDate?: string|Date|null, dateFormat?: string}>} [config.columns=[]] - Column schema. Select options may be a static array, a function returning an array, or an async function/Promise resolving to an array. `type: 'search-select'` renders a searchable input backed by a datalist while still storing the selected option value. Select options are fetched once per column and cached for the current table instance.
@@ -7410,6 +7412,8 @@ function renderInteractiveTable(config = {}) {
         showClearButton: false,
         clearButtonText: 'Clear',
         clearButtonClassName: '',
+        confirmOnClear: true,
+        clearConfirmMessage: 'Are you sure you want to clear all rows? This will remove any unsaved table data.',
         autoAppendRow: false,
         createEmptyRow: null,
         isRowPopulated: null,
@@ -8057,6 +8061,31 @@ function renderInteractiveTable(config = {}) {
 
     const clearTable = async () => {
         if (isSubmitting) return;
+
+        const shouldConfirmClear = settings.confirmOnClear !== false;
+        const clearConfirmMessage = String(settings.clearConfirmMessage || '').trim()
+            || 'Are you sure you want to clear all rows? This will remove any unsaved table data.';
+
+        if (shouldConfirmClear) {
+            const confirmationResult = await showConfirmationDialog({
+                title: 'Clear rows',
+                message: clearConfirmMessage,
+                buttons: [
+                    {
+                        text: 'Cancel',
+                        className: 'kn-button is-secondary',
+                        value: 'cancel',
+                    },
+                    {
+                        text: 'Clear rows',
+                        className: 'kn-button is-danger',
+                        value: 'confirm',
+                    },
+                ],
+            });
+
+            if (confirmationResult?.value !== 'confirm') return;
+        }
 
         rowsData = [];
         ensureTrailingEmptyRow();
@@ -16444,6 +16473,42 @@ function showConfirmationDialog(options = {}) {
         titleEl.id = titleId;
         titleEl.textContent = config.title;
 
+        if (!config.styling.overlayClass) {
+            Object.assign(overlay.style, {
+                position: 'fixed',
+                inset: '0',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '24px',
+                backgroundColor: 'rgba(15, 23, 42, 0.55)',
+                zIndex: '2010',
+                boxSizing: 'border-box',
+            });
+        }
+
+        if (!containerClass) {
+            Object.assign(dialog.style, {
+                width: 'min(100%, 520px)',
+                maxHeight: 'calc(100vh - 48px)',
+                overflowY: 'auto',
+                background: '#ffffff',
+                color: '#1f2937',
+                borderRadius: '12px',
+                boxShadow: '0 20px 55px rgba(15, 23, 42, 0.28)',
+                padding: '24px',
+                boxSizing: 'border-box',
+            });
+        }
+
+        if (!config.styling.titleClass) {
+            Object.assign(titleEl.style, {
+                margin: '0 0 12px',
+                fontSize: '20px',
+                lineHeight: '1.3',
+            });
+        }
+
         dialog.setAttribute('role', 'dialog');
         dialog.setAttribute('aria-modal', 'true');
         dialog.setAttribute('aria-labelledby', titleId);
@@ -16453,6 +16518,12 @@ function showConfirmationDialog(options = {}) {
         messages.forEach(function (messagePart) {
             const paragraph = document.createElement('p');
             paragraph.className = config.styling.messageClass;
+            if (!config.styling.messageClass) {
+                Object.assign(paragraph.style, {
+                    margin: '0 0 12px',
+                    lineHeight: '1.5',
+                });
+            }
             paragraph.innerHTML = String(messagePart);
             dialog.appendChild(paragraph);
         });
@@ -16460,11 +16531,23 @@ function showConfirmationDialog(options = {}) {
         if (config.contentHtml) {
             const contentEl = document.createElement('div');
             contentEl.className = config.styling.contentClass;
+            if (!config.styling.contentClass) {
+                contentEl.style.marginBottom = '16px';
+            }
             contentEl.innerHTML = config.contentHtml;
             dialog.appendChild(contentEl);
         }
 
         buttonsWrap.className = config.styling.buttonsClass;
+        if (!config.styling.buttonsClass) {
+            Object.assign(buttonsWrap.style, {
+                display: 'flex',
+                justifyContent: 'flex-end',
+                gap: '8px',
+                flexWrap: 'wrap',
+                marginTop: '20px',
+            });
+        }
         dialog.appendChild(buttonsWrap);
 
         function cleanup(result) {


### PR DESCRIPTION
## Changelog

- Added optional clear button support to `renderInteractiveTable`, with configurable button text and CSS classes, rendered in a right-aligned toolbar above the table.
- Added `onClear` and `controller.clear()` support so apps can clear interactive table rows from either the UI or code and run follow-up logic after the table is reset.
- Added configurable clear confirmation support with `confirmOnClear` and `clearConfirmMessage`, defaulting to a confirmation step before rows are cleared.
- Updated the clear confirmation flow to use the shared `showConfirmationDialog` helper instead of the browser confirm dialog.
- Improved `showConfirmationDialog` so unstyled calls render as a centred modal overlay by default instead of appearing as unstyled page content.
- Documented the interactive table clear-button and clear-confirmation configuration in the interactive table wiki.