### PR TITLE
feat: add view column index and selector resolution methods to KnackNavigator

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -47,6 +47,8 @@ class KnackNavigator {
         this._fieldIdByViewLabelCache = new Map();
         this._fieldIdByViewHeaderCache = new Map();
         this._viewHeaderByFieldIdCache = new Map();
+        this._viewColumnIndexCache = new Map();
+        this._viewColumnSelectorCache = new Map();
         this._fieldMetaCache = new Map();
         this._fieldTypeCache = new Map();
     }
@@ -289,6 +291,128 @@ class KnackNavigator {
 
         this._viewHeaderByFieldIdCache.set(cacheKey, resolvedHeader);
         return resolvedHeader;
+    }
+
+    /**
+     * Returns the 1-based visual column index for a view column.
+     * Supports field-backed columns and header-only action columns such as Edit.
+     * @param {string|number} viewId - View id to inspect.
+     * @param {string|number|Object} columnRef - Field id, header text, or column metadata.
+     * @returns {number} 1-based column index, or 0 when not found.
+     */
+    getViewColumnIndex(viewId, columnRef) {
+        const normalizedViewId = this.normalizeViewId(viewId);
+        if (!normalizedViewId || !columnRef) return 0;
+
+        const renderedColumnIndex = this.getRenderedViewColumnIndex(normalizedViewId, columnRef);
+        if (renderedColumnIndex > 0) {
+            return renderedColumnIndex;
+        }
+
+        const cacheRef = typeof columnRef === 'object'
+            ? `${this.normalizeFieldId(columnRef?.field?.key || columnRef?.id || '')}::${this.normalizeViewColumnHeader(columnRef?.header || '')}`
+            : `${this.normalizeFieldId(columnRef)}::${this.normalizeViewColumnHeader(columnRef)}`;
+        const cacheKey = `${normalizedViewId}::${cacheRef}`;
+        if (this._viewColumnIndexCache.has(cacheKey)) {
+            return this._viewColumnIndexCache.get(cacheKey);
+        }
+
+        const columns = this.getViewColumns(normalizedViewId);
+        const column = this.getViewColumn(normalizedViewId, columnRef);
+        const columnIndex = column ? columns.findIndex((candidate) => candidate === column) + 1 : 0;
+
+        this._viewColumnIndexCache.set(cacheKey, columnIndex > 0 ? columnIndex : 0);
+        return columnIndex > 0 ? columnIndex : 0;
+    }
+
+    /**
+     * Resolves the live rendered column index from the table DOM.
+     * This accounts for runtime-injected columns such as selection checkboxes.
+     * @param {string|number} viewId - View id to inspect.
+     * @param {string|number|Object} columnRef - Field id, header text, or column metadata.
+     * @returns {number} 1-based column index, or 0 when not found.
+     */
+    getRenderedViewColumnIndex(viewId, columnRef) {
+        const normalizedViewId = this.normalizeViewId(viewId);
+        if (!normalizedViewId || !columnRef) return 0;
+
+        const viewElement = typeof document !== 'undefined'
+            ? document.getElementById(normalizedViewId)
+            : null;
+        if (!(viewElement instanceof HTMLElement)) return 0;
+
+        const headerCells = Array.from(viewElement.querySelectorAll('thead tr:last-child > th'));
+        if (!headerCells.length) return 0;
+
+        const resolvedColumn = this.getViewColumn(normalizedViewId, columnRef);
+        const resolvedFieldId = this.normalizeFieldId(resolvedColumn?.field?.key || resolvedColumn?.id || columnRef);
+        const resolvedHeader = this.normalizeViewColumnHeader(resolvedColumn?.header || columnRef);
+
+        const matchingIndex = headerCells.findIndex((headerCell) => {
+            if (!(headerCell instanceof HTMLElement)) return false;
+
+            const headerFieldKey = this.normalizeFieldId(headerCell.getAttribute('data-field-key') || '');
+            if (resolvedFieldId && headerFieldKey && headerFieldKey === resolvedFieldId) {
+                return true;
+            }
+
+            if (resolvedFieldId && headerCell.classList.contains(resolvedFieldId)) {
+                return true;
+            }
+
+            if (!resolvedHeader) {
+                return false;
+            }
+
+            return this.normalizeViewColumnHeader(headerCell.innerHTML || headerCell.textContent || '') === resolvedHeader;
+        });
+
+        return matchingIndex >= 0 ? matchingIndex + 1 : 0;
+    }
+
+    /**
+     * Returns DOM selectors for a view column.
+     * Field-backed columns resolve to field selectors, while header-only columns fall back to nth-child selectors.
+     * @param {string|number} viewId - View id to inspect.
+     * @param {string|number|Object} columnRef - Field id, header text, or column metadata.
+     * @returns {Array<string>} CSS selectors that target the column header and cells.
+     */
+    getViewColumnSelectors(viewId, columnRef) {
+        const normalizedViewId = this.normalizeViewId(viewId);
+        if (!normalizedViewId || !columnRef) return [];
+
+        const cacheRef = typeof columnRef === 'object'
+            ? `${this.normalizeFieldId(columnRef?.field?.key || columnRef?.id || '')}::${this.normalizeViewColumnHeader(columnRef?.header || '')}`
+            : `${this.normalizeFieldId(columnRef)}::${this.normalizeViewColumnHeader(columnRef)}`;
+        const cacheKey = `${normalizedViewId}::${cacheRef}`;
+        if (this._viewColumnSelectorCache.has(cacheKey)) {
+            return this._viewColumnSelectorCache.get(cacheKey);
+        }
+
+        const selectors = [];
+        const column = this.getViewColumn(normalizedViewId, columnRef);
+        const fieldId = this.normalizeFieldId(column?.field?.key || column?.id || columnRef);
+        if (fieldId) {
+            selectors.push(
+                `th.${fieldId}`,
+                `td.${fieldId}`,
+                `th[data-field-key="${fieldId}"]`,
+                `td[data-field-key="${fieldId}"]`
+            );
+        }
+
+        const columnIndex = this.getViewColumnIndex(normalizedViewId, columnRef);
+        if (columnIndex > 0) {
+            selectors.push(
+                `thead tr > th:nth-child(${columnIndex})`,
+                `tbody tr > td:nth-child(${columnIndex})`,
+                `colgroup col:nth-child(${columnIndex})`
+            );
+        }
+
+        const uniqueSelectors = Array.from(new Set(selectors.filter(Boolean)));
+        this._viewColumnSelectorCache.set(cacheKey, uniqueSelectors);
+        return uniqueSelectors;
     }
 
     /**
@@ -1639,6 +1763,320 @@ function normalizeBulkActionKeywordGroupsInput(keywordSource, keywordName = '_bu
 }
 
 /**
+ * Returns true when a value should count as present for rule evaluation.
+ * @param {*} value - Value to inspect.
+ * @returns {boolean} Whether the value is meaningfully present.
+ */
+function bulkActionHasMeaningfulValue(value) {
+    if (Array.isArray(value)) {
+        return value.some((entry) => bulkActionHasMeaningfulValue(entry));
+    }
+
+    if (value && typeof value === 'object') {
+        const connectionRef = knackValueResolver.toConnectionRef(value);
+        if (connectionRef?.id) return true;
+
+        return Object.values(value).some((entry) => bulkActionHasMeaningfulValue(entry));
+    }
+
+    if (typeof value === 'string') {
+        return value.trim() !== '';
+    }
+
+    return value !== undefined && value !== null;
+}
+
+/**
+ * Normalises a value into a comparable primitive or primitive array.
+ * @param {*} value - Source value.
+ * @returns {string|Array<string>} Comparable value.
+ */
+function bulkActionNormalizeComparableValue(value) {
+    if (Array.isArray(value)) {
+        return value
+            .flatMap((entry) => {
+                const normalized = bulkActionNormalizeComparableValue(entry);
+                return Array.isArray(normalized) ? normalized : [normalized];
+            })
+            .map((entry) => knackValueResolver.toStringSafe(entry).trim().toLowerCase())
+            .filter(Boolean);
+    }
+
+    if (value && typeof value === 'object') {
+        const connectionRef = knackValueResolver.toConnectionRef(value);
+        if (connectionRef?.id) {
+            return knackValueResolver.toStringSafe(connectionRef.id).trim().toLowerCase();
+        }
+
+        return knackValueResolver.toStringSafe(
+            value.id
+            ?? value.identifier
+            ?? value.value
+            ?? value.date
+            ?? value.iso_date
+            ?? value.time
+            ?? value.time_formatted
+        ).trim().toLowerCase();
+    }
+
+    return knackValueResolver.toStringSafe(value).trim().toLowerCase();
+}
+
+/**
+ * Normalises a literal record-rule value into a request payload value.
+ * @param {*} value - Rule literal value.
+ * @param {string} fieldType - Destination Knack field type.
+ * @returns {*} Request-ready value.
+ */
+function bulkActionNormalizeRuleLiteralValue(value, fieldType) {
+    if (value === undefined || value === null) {
+        return bulkActionGetEmptyRequestValue(null, fieldType);
+    }
+
+    if (Array.isArray(value)) {
+        if (!value.length) {
+            return bulkActionGetEmptyRequestValue(null, fieldType);
+        }
+
+        if (fieldType === 'connection' || fieldType === 'multiple_choice') {
+            const requestValue = knackValueResolver.toRequestValue({
+                rawValue: value,
+                displayValue: value,
+                fieldType
+            });
+            return requestValue !== undefined ? requestValue : bulkActionGetEmptyRequestValue(null, fieldType);
+        }
+
+        const firstValue = value[0];
+        const requestValue = knackValueResolver.toRequestValue({
+            rawValue: firstValue,
+            displayValue: firstValue,
+            fieldType
+        });
+        if (requestValue !== undefined) return requestValue;
+
+        return bulkActionHasMeaningfulValue(firstValue)
+            ? firstValue
+            : bulkActionGetEmptyRequestValue(null, fieldType);
+    }
+
+    const requestValue = knackValueResolver.toRequestValue({
+        rawValue: value,
+        displayValue: value,
+        fieldType
+    });
+    if (requestValue !== undefined) return requestValue;
+
+    return bulkActionHasMeaningfulValue(value)
+        ? value
+        : bulkActionGetEmptyRequestValue(null, fieldType);
+}
+
+/**
+ * Returns a current-date request value for a field.
+ * @param {string} fieldType - Destination Knack field type.
+ * @returns {*} Request-ready current date value.
+ */
+function bulkActionGetCurrentDateRuleValue(fieldType) {
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const year = String(now.getFullYear());
+    const dateValue = `${month}/${day}/${year}`;
+
+    const requestValue = knackValueResolver.toRequestValue({
+        rawValue: dateValue,
+        displayValue: dateValue,
+        fieldType
+    });
+
+    return requestValue !== undefined ? requestValue : dateValue;
+}
+
+/**
+ * Returns the current user id for rule-driven updates.
+ * @returns {string} Logged-in user id.
+ */
+function bulkActionGetCurrentUserRuleValue() {
+    return knackValueResolver.toStringSafe(Knack?.getUserAttributes?.()?.id);
+}
+
+/**
+ * Evaluates a single Knack record-rule criterion against a source record.
+ * @param {Object} sourceRecord - Source record for the target row.
+ * @param {Object} criterion - Knack criterion definition.
+ * @returns {boolean} Whether the criterion matches.
+ */
+function bulkActionRecordRuleCriterionMatches(sourceRecord, criterion = {}) {
+    const fieldKey = knackNavigator.normalizeFieldId(criterion?.field);
+    const operator = knackValueResolver.toStringSafe(criterion?.operator).trim().toLowerCase();
+    if (!fieldKey || !operator) return true;
+
+    const fieldType = knackValueResolver.getFieldType(fieldKey);
+    const leftValue = knackValueResolver.resolve(sourceRecord, fieldKey, {
+        mode: 'request',
+        fallback: sourceRecord?.[fieldKey]
+    });
+
+    if (operator === 'is blank') {
+        return !bulkActionHasMeaningfulValue(leftValue);
+    }
+
+    if (operator === 'is not blank') {
+        return bulkActionHasMeaningfulValue(leftValue);
+    }
+
+    const rightValue = bulkActionNormalizeRuleLiteralValue(criterion?.value, fieldType);
+    const normalizedLeft = bulkActionNormalizeComparableValue(leftValue);
+    const normalizedRight = bulkActionNormalizeComparableValue(rightValue);
+    const leftValues = Array.isArray(normalizedLeft) ? normalizedLeft : [normalizedLeft];
+    const rightValues = Array.isArray(normalizedRight) ? normalizedRight : [normalizedRight];
+
+    switch (operator) {
+        case 'is':
+            return rightValues.every((value) => leftValues.includes(value));
+        case 'is not':
+            return rightValues.every((value) => !leftValues.includes(value));
+        case 'contains':
+            return rightValues.every((value) => leftValues.some((entry) => entry.includes(value)));
+        case 'does not contain':
+            return rightValues.every((value) => leftValues.every((entry) => !entry.includes(value)));
+        default:
+            return true;
+    }
+}
+
+/**
+ * Returns true when a source record matches all criteria for a Knack record rule.
+ * @param {Object} sourceRecord - Source record for the target row.
+ * @param {Array<Object>} criteria - Knack criteria list.
+ * @returns {boolean} Whether all criteria match.
+ */
+function bulkActionRecordRuleMatches(sourceRecord, criteria = []) {
+    return (Array.isArray(criteria) ? criteria : []).every((criterion) => bulkActionRecordRuleCriterionMatches(sourceRecord, criterion));
+}
+
+/**
+ * Resolves a record-rule value into an update payload value.
+ * @param {Object} [options={}] - Rule resolution options.
+ * @returns {*} Request-ready field value.
+ */
+function bulkActionResolveRecordRuleValue({ valueRule = {}, sourceRecord = null, submittedRecord = null } = {}) {
+    const fieldKey = knackNavigator.normalizeFieldId(valueRule?.field);
+    if (!fieldKey) return undefined;
+
+    const fieldType = knackValueResolver.getFieldType(fieldKey);
+    const ruleType = knackValueResolver.toStringSafe(valueRule?.type).trim().toLowerCase();
+
+    if (ruleType === 'record') {
+        const inputFieldKey = knackNavigator.normalizeFieldId(valueRule?.input || valueRule?.connection_field);
+        if (!inputFieldKey) {
+            return bulkActionGetEmptyRequestValue(null, fieldType);
+        }
+
+        const requestValue = knackValueResolver.resolve(sourceRecord, inputFieldKey, {
+            mode: 'request',
+            fallback: sourceRecord?.[inputFieldKey]
+        });
+
+        return requestValue !== undefined ? requestValue : bulkActionGetEmptyRequestValue(null, fieldType);
+    }
+
+    if (ruleType === 'user') {
+        const submittedValue = knackValueResolver.resolve(submittedRecord, fieldKey, { mode: 'request', fallback: undefined });
+        return submittedValue !== undefined ? submittedValue : bulkActionGetCurrentUserRuleValue();
+    }
+
+    if (ruleType === 'current_date') {
+        const submittedValue = knackValueResolver.resolve(submittedRecord, fieldKey, { mode: 'request', fallback: undefined });
+        return submittedValue !== undefined ? submittedValue : bulkActionGetCurrentDateRuleValue(fieldType);
+    }
+
+    return bulkActionNormalizeRuleLiteralValue(valueRule?.value, fieldType);
+}
+
+/**
+ * Builds an update payload from Knack record rules for a target source record.
+ * @param {Object} [options={}] - Rule payload options.
+ * @returns {Object} Request payload derived from matching record rules.
+ */
+function bulkActionBuildRecordRulePayload({ recordRules = [], sourceRecord = null, submittedRecord = null } = {}) {
+    if (!sourceRecord || typeof sourceRecord !== 'object') return {};
+
+    return (Array.isArray(recordRules) ? recordRules : []).reduce((payload, rule) => {
+        if (knackValueResolver.toStringSafe(rule?.action).trim().toLowerCase() !== 'record') {
+            return payload;
+        }
+
+        if (!bulkActionRecordRuleMatches(sourceRecord, rule?.criteria)) {
+            return payload;
+        }
+
+        const values = Array.isArray(rule?.values) ? rule.values : [];
+        values.forEach((valueRule) => {
+            const fieldKey = knackNavigator.normalizeFieldId(valueRule?.field);
+            if (!fieldKey) return;
+
+            const resolvedValue = bulkActionResolveRecordRuleValue({
+                valueRule,
+                sourceRecord,
+                submittedRecord
+            });
+
+            if (resolvedValue === undefined) return;
+            payload[fieldKey] = resolvedValue;
+        });
+
+        return payload;
+    }, {});
+}
+
+/**
+ * Returns true when a form has declared runtime inputs in the view metadata.
+ * @param {Object} viewObject - Knack view metadata.
+ * @returns {boolean} Whether the form declares inputs.
+ */
+function bulkActionFormHasDeclaredInputs(viewObject = {}) {
+    if (Array.isArray(viewObject?.inputs) && viewObject.inputs.length) {
+        return true;
+    }
+
+    return (Array.isArray(viewObject?.groups) ? viewObject.groups : []).some((group) => {
+        return (Array.isArray(group?.columns) ? group.columns : []).some((column) => {
+            return Array.isArray(column?.inputs) && column.inputs.length > 0;
+        });
+    });
+}
+
+/**
+ * Creates a per-record callback for update forms that rely entirely on Knack record rules.
+ * @param {string} formViewId - Target form view id.
+ * @param {Object} viewObject - Target form metadata.
+ * @returns {Function|null} Callback that derives payloads from record rules.
+ */
+function bulkActionCreateRuleDrivenUpdateDataCallback(formViewId, viewObject = {}) {
+    const normalizedViewId = knackNavigator.normalizeViewId(formViewId);
+    const normalizedViewObject = viewObject && typeof viewObject === 'object'
+        ? viewObject
+        : knackNavigator.getViewObject(normalizedViewId);
+    const recordRules = Array.isArray(normalizedViewObject?.rules?.records)
+        ? normalizedViewObject.rules.records
+        : [];
+
+    if (!normalizedViewId || bulkActionFormHasDeclaredInputs(normalizedViewObject) || !recordRules.length) {
+        return null;
+    }
+
+    return function bulkActionRuleDrivenUpdateDataCallback(_payload = {}, context = {}) {
+        return bulkActionBuildRecordRulePayload({
+            recordRules,
+            sourceRecord: context?.sourceRecord,
+            submittedRecord: context?.record
+        });
+    };
+}
+
+/**
  * Parses bulk-action keyword groups into grid/form action configuration.
  * @param {*} keywordGroups - Raw keyword groups from the Knack keyword parser.
  * @param {Object} [options={}] - Parsing options and callback registries.
@@ -1760,6 +2198,10 @@ function parseBulkActionKeywordGroups(keywordGroups, options = {}) {
             }
         }
 
+        const autoRulePayloadCallback = !resolvedDataCallback
+            ? bulkActionCreateRuleDrivenUpdateDataCallback(formViewId, view)
+            : null;
+
         actions.push({
             key: `${operation}:${formViewId}`,
             label,
@@ -1767,7 +2209,7 @@ function parseBulkActionKeywordGroups(keywordGroups, options = {}) {
             target: formViewId,
             operation,
             recordFieldId: parsed.recordFieldId || defaultRecordFieldId,
-            dataCallback: resolvedDataCallback
+            dataCallback: resolvedDataCallback || autoRulePayloadCallback
         });
     });
 
@@ -4724,8 +5166,16 @@ async function replicateBulkActionSubmittedRecord({ action, bulkState, record, a
         ? bulkActionNormalizeFieldKeys(bulkState?.formFieldKeys || bulkActionGetFormFieldKeys(formViewRef))
         : [];
     const excludeFieldKeys = mode === 'create' && recordFieldId ? [recordFieldId] : [];
+    const effectiveDataCallback = typeof action?.dataCallback === 'function'
+        ? action.dataCallback
+        : (mode === 'update' && !includeFieldKeys.length
+            ? bulkActionCreateRuleDrivenUpdateDataCallback(formViewRef)
+            : null);
+    const effectiveAction = effectiveDataCallback
+        ? { ...action, dataCallback: effectiveDataCallback }
+        : action;
 
-    if (mode === 'update' && !includeFieldKeys.length) {
+    if (mode === 'update' && !includeFieldKeys.length && typeof effectiveAction?.dataCallback !== 'function') {
         throw new Error('Bulk form replication could not determine the visible form fields for update mode.');
     }
 
@@ -4775,7 +5225,7 @@ async function replicateBulkActionSubmittedRecord({ action, bulkState, record, a
         mode,
         remainingIds,
         basePayload,
-        action,
+        action: effectiveAction,
         sourceController,
         processedRecordId,
         sourceViewId,


### PR DESCRIPTION
## Summary
Added shared KnackNavigator helpers to resolve live table column indexes and selectors, including support for runtime-injected columns and header-only action columns.
Extended bulk action parsing so update-form actions can attach automatic per-record payload callbacks when a target form is driven entirely by Knack record rules.
Added rule-evaluation helpers for bulk actions so shared code can derive update payloads from Knack record criteria, literal values, current-user values, and current-date values.
Fixed bulk form replication for zero-input update forms by falling back to rule-driven payload generation instead of failing when no visible form fields are present.
Kept the fix generic in the shared library so app-side bulk actions can use rule-only update forms without embedding app-specific logic in knack-functions.

## Changelog

Added shared view-column index and selector helpers so apps can target table columns reliably, including columns affected by runtime DOM changes.
Fixed bulk actions for update forms that rely on Knack record rules instead of visible form inputs.
Added automatic rule-driven payload generation for bulk action update forms, including support for record-copy, current user, current date, and literal rule values.
Prevented bulk form replication from failing when an update form has no visible editable fields but can still be resolved from form metadata and record rules.