### PR TITLE
feat: add method to normalize raw field map in KnackNavigator

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -103,6 +103,20 @@ class KnackNavigator {
     }
 
     /**
+     * Normalises every field reference in a field map to its `_raw` companion key.
+     * @param {Object} [fieldMap={}] - Field map keyed by logical names.
+     * @returns {Object} Field map with normalised raw field ids.
+     */
+    normalizeRawFieldMap(fieldMap = {}) {
+        return Object.fromEntries(
+            Object.entries(fieldMap || {}).map(([fieldKey, fieldValue]) => [
+                fieldKey,
+                this.normalizeRawFieldId(fieldValue),
+            ])
+        );
+    }
+
+    /**
      * Returns the DOM wrapper for a Knack field inside a view.
      * @param {Element} viewRoot - Root element for the view.
      * @param {string|number} fieldId - Field id to resolve.


### PR DESCRIPTION
## Summary

This PR adds a small shared `KnackNavigator` helper for cases where a caller already has a field map and needs the `_raw` equivalents of those field ids without normalising each field manually.

The helper keeps that transformation generic and reusable in `knack-functions`, so app code can pre-normalise raw field maps at the boundary instead of repeating `_raw` conversion throughout downstream logic.

## Changelog

- add `normalizeRawFieldMap(fieldMap)` to `KnackNavigator`
- return a field map with each field id converted to its `_raw` companion key using the existing raw-field normalisation logic
- support app code that wants to pre-normalise raw field maps once at the boundary instead of repeating per-field `_raw` conversion