### PR TITLE
Update updateDateFields

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -16746,6 +16746,23 @@ function getRecordID(part = null) {
     return parts[parts.length - part];
 }
 
+/**
+ * Extracts the URL hash segment immediately before a given scene slug.
+ * Knack routes nested pages as: #area/parent-list/{parentId}/scene-slug/{recordId}/
+ * so finding the slug position and stepping back one gives the parent record ID.
+ * @param {string} sceneSlug - Scene slug to locate (e.g. 'edit-product-availability').
+ * @returns {string} The record ID segment before the slug, or empty string if not found.
+ */
+function getIdBeforeSceneSlug(sceneSlug) {
+    const hash = String(window.location.hash || '').replace(/^#/, '');
+    const parts = hash.split('/').filter(Boolean);
+    const slugIdx = parts.indexOf(sceneSlug);
+    if (slugIdx < 1) {
+        return '';
+    }
+    return parts[slugIdx - 1];
+}
+
 /****Display Notifications
  * @param {string} insertNotificationAfter - The selctor to attach the notification too
  * @param {string} notificationTxt - text of notification

--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -9908,13 +9908,27 @@ function updateUserFields(viewId, fieldIds) {
     });
 }
 
-/** Update date fields with the current date and time.
+/** Update date fields with the current date and optional current time.
  * @param {string} viewId - The ID of the view.
- * @param {Array} fieldIds - Array of date field IDs.*/
-function updateDateFields(viewId, fieldIds) {
+ * @param {Array<number|Object>} fieldIds - Array of field IDs or field configs.
+ * Field config supports: `{ fieldId, insertTime }` to override the default includeTime behaviour.
+ * @param {boolean} [includeTime=true] - When true, also set the time input for date_time fields.
+ * Per-field config can override via `insertTime` property.
+ */
+function updateDateFields(viewId, fieldIds, includeTime = true) {
     const currentDate = new Date();
-    fieldIds.forEach(foundFieldId => {
+
+    fieldIds.forEach((fieldEntry) => {
         if ($('#view_3404').length > 0) return false; // Submit Support Request Form
+
+        const isConfigObject = fieldEntry && typeof fieldEntry === 'object';
+        const foundFieldId = isConfigObject ? Number(fieldEntry.fieldId) : Number(fieldEntry);
+        if (!Number.isFinite(foundFieldId) || foundFieldId <= 0) return;
+
+        let shouldIncludeTime = includeTime;
+        if (isConfigObject && typeof fieldEntry.insertTime === 'boolean') {
+            shouldIncludeTime = fieldEntry.insertTime;
+        }
 
         const dateField = $(`#${viewId}-field_${foundFieldId}`);
         const timeField = $(`#${viewId}-field_${foundFieldId}-time`);
@@ -9923,8 +9937,10 @@ function updateDateFields(viewId, fieldIds) {
             dateField.val(getDateUKFormat(currentDate));
         }
 
-        if (!timeField.val()) {
-            const timeString = `${currentDate.getHours()}:${currentDate.getMinutes()}`;
+        if (shouldIncludeTime && !timeField.val()) {
+            const hours = String(currentDate.getHours()).padStart(2, '0');
+            const minutes = String(currentDate.getMinutes()).padStart(2, '0');
+            const timeString = `${hours}:${minutes}`;
             timeField.val(timeString);
         }
     });


### PR DESCRIPTION
Summary

Adds a new shared URL helper for nested Knack scene routing and updates updateDateFields so callers can control whether time is inserted for date_time fields.

Changelog

Added getIdBeforeSceneSlug(sceneSlug) to knackFunctions.js

The helper reads the current URL hash, finds the provided scene slug, and returns the segment immediately before it

This supports nested Knack routes where the parent record id appears before a known scene slug

Updated updateDateFields(viewId, fieldIds, includeTime = true)

Added a new optional includeTime parameter with a default of true

date_time fields now only have their time value populated when includeTime is true

Added support for per-field override via config objects using insertTime: true/false

Time values are now zero-padded when inserted

Why

getIdBeforeSceneSlug gives apps a reusable way to resolve parent ids from nested Knack hashes without repeating route parsing logic
The updateDateFields change makes automatic date/time population more flexible, especially for flows that should stamp a date but intentionally leave time blank
Testing

Reviewed the knackFunctions.js diff against main
Confirmed getIdBeforeSceneSlug(sceneSlug) safely returns the id before the matching scene slug or an empty string when no match exists
Confirmed updateDateFields now:
defaults to inserting time
skips time insertion when includeTime is false
supports field-level insertTime overrides
writes zero-padded times when time is included