### PR TITLE
feat(knackNavigator): add normaliseViewMap helper

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -118,6 +118,25 @@ class KnackNavigator {
     }
 
     /**
+     * Normalises every view reference in a view map.
+     * @param {Object} [viewMap={}] - View map keyed by logical names where each value is a view id or array of view ids.
+     * @returns {Object} View map with normalised view ids (string or array).
+     */
+    normaliseViewMap(viewMap = {}) {
+        return Object.fromEntries(
+            Object.entries(viewMap || {}).map(([key, value]) => {
+                if (Array.isArray(value)) {
+                    const normalized = value.map((v) => this.normalizeViewId(v)).filter(Boolean);
+                    // Return a single string (first normalized id) or empty string
+                    return [key, normalized[0] || ''];
+                }
+
+                return [key, this.normalizeViewId(value) || ''];
+            })
+        );
+    }
+
+    /**
      * Returns the DOM wrapper for a Knack field inside a view.
      * @param {Element} viewRoot - Root element for the view.
      * @param {string|number} fieldId - Field id to resolve.


### PR DESCRIPTION
## Summary

Add `knackNavigator.normaliseViewMap` helper to normalise configured view maps and return a consistent map of view IDs. This supports consistent view-render binding patterns across apps (for example, GAP-Track) without embedding app-specific IDs in the shared library.

## Changelog

- Add `normaliseViewMap` helper to `knackNavigator` to normalise configured view maps and return the first valid view id for each key.

## Testing

- Pushed branch `normaliseViewMap` and verified commits (see branch origin/normaliseViewMap).
- Updated GAP-Track to use `normaliseViewMap` for account form render handlers and verified code references locally.
- Only source files were changed; no generated `dist/`, SRI, or manifest files were edited in this PR per project instructions.