### PR TITLE
Fix multi-form coordinator destroy cleanup

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -12151,8 +12151,13 @@ class MultiFormSubmissionCoordinator {
         }
 
         // Clean up jQuery event handlers using stored namespaces
-        this.eventHandlers.forEach((eventNamespace) => {
-            $(document).off(eventNamespace);
+        this.eventHandlers.forEach((eventHandler) => {
+            if (typeof eventHandler === 'function') {
+                eventHandler();
+                return;
+            }
+
+            $(document).off(eventHandler);
         });
 
         this.eventHandlers.clear();


### PR DESCRIPTION
## Summary

- fix `MultiFormSubmissionCoordinator.destroy()` so stored cleanup callbacks are executed instead of being passed to `.off(...)` as event names
- prevent teardown from throwing `TypeError: e.replace is not a function` when a coordinator instance cleans up submit outcome listeners

## Changelog

- Fix multi-form coordinator teardown so coordinated submit cleanup no longer throws when a stored cleanup callback is registered