### PR TITLE
Prevent MQT toggles on no-inline-edit cells

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -19909,7 +19909,10 @@ class CAMultiChoiceQuickToggle {
             if (this.inlineEditing && !col.ignore_edit) {
                 this.getViewRoot()
                     ?.querySelectorAll(`td.${fieldId}.cell-edit`)
-                    .forEach((cell) => cell.classList.add('mqtCellClickable'));
+                    .forEach((cell) => {
+                        if (!(cell instanceof HTMLElement) || cell.classList.contains('ktlNoInlineEdit')) return;
+                        cell.classList.add('mqtCellClickable');
+                    });
             }
         });
     }
@@ -20007,7 +20010,12 @@ class CAMultiChoiceQuickToggle {
         this.getViewRoot()
             ?.querySelectorAll('.mqtCellClickable')
             .forEach((cell) => {
-                if (!(cell instanceof HTMLElement) || cell.dataset.mqtBound === 'true') return;
+                if (!(cell instanceof HTMLElement)) return;
+                if (cell.classList.contains('ktlNoInlineEdit')) {
+                    cell.classList.remove('mqtCellClickable');
+                    return;
+                }
+                if (cell.dataset.mqtBound === 'true') return;
                 cell.dataset.mqtBound = 'true';
                 cell.addEventListener('click', (e) => this.handleCellClick(e), true);
             });
@@ -20021,10 +20029,12 @@ class CAMultiChoiceQuickToggle {
     handleCellClick(e) {
         if (document.querySelector('.bulkEditCb:checked')) return;
 
-        e.stopImmediatePropagation();
-
         const eventTarget = e.target instanceof Element ? e.target : null;
         const clickedCell = eventTarget?.closest('td');
+        if (clickedCell instanceof HTMLElement && clickedCell.classList.contains('ktlNoInlineEdit')) return;
+
+        e.stopImmediatePropagation();
+
         const fieldId = knackNavigator.normalizeFieldId(
             clickedCell?.getAttribute('data-field-key')
             || eventTarget?.getAttribute('data-field-key')


### PR DESCRIPTION
## Summary

- stop mqt from marking ktlNoInlineEdit cells as clickable during setup
- skip binding and handling quick-toggle clicks when PSA has already marked a cell as ktlNoInlineEdit

## Changelog

- make shared mqt quick toggles respect PSA no-inline-edit cells

## Testing

- Not run (browser-side validation not run in this environment)