### PR TITLE
Prevent repeated version-refresh reloads

### DIFF
--- a/knackFunctions.js
+++ b/knackFunctions.js
@@ -2590,6 +2590,8 @@ function createVersionRefreshController(options = {}) {
 
         internalState.reloadTimerId = window.setTimeout(function () {
             internalState.reloadTimerId = 0;
+            internalState.pendingRequestActive = false;
+            stopPendingRefreshWatch();
             writeState(mergeStoredState({
                 targetVersion: '',
                 lastReloadedTarget: targetVersion,
@@ -2628,6 +2630,12 @@ function createVersionRefreshController(options = {}) {
         const storedState = readState();
         const userVersion = normalizeVersion(payload.userVersion);
         const targetVersion = normalizeVersion(payload.targetVersion);
+        const shouldWaitForUserVersionSync = Boolean(
+            normalizedSyncUserVersionFieldId
+            && userVersion
+            && targetVersion
+            && userVersion !== targetVersion
+        );
         if (userVersion) {
             storeUserVersion(userVersion);
         }
@@ -2649,6 +2657,12 @@ function createVersionRefreshController(options = {}) {
         }
 
         if (internalState.pendingRequestActive && storedState.targetVersion === targetVersion) {
+            if (shouldWaitForUserVersionSync) {
+                ensurePendingRefreshWatch();
+                showDeferredRefreshNotice(targetVersion);
+                return;
+            }
+
             ensurePendingRefreshWatch();
             runRefreshIfSafe();
             return;
@@ -2659,6 +2673,13 @@ function createVersionRefreshController(options = {}) {
             targetVersion,
             userVersion: userVersion || storedState.userVersion,
         }, storedState));
+
+        if (shouldWaitForUserVersionSync) {
+            ensurePendingRefreshWatch();
+            showDeferredRefreshNotice(targetVersion);
+            return;
+        }
+
         ensurePendingRefreshWatch();
         runRefreshIfSafe();
     }


### PR DESCRIPTION
## Summary

- defer version-refresh reloads until the user-version field sync has completed when the iframe reports a target-version mismatch
- keep repeated mismatch messages for the same pending target in the wait state instead of re-triggering the reload path
- clear the pending refresh flag and observer before reloading so the same page instance does not re-arm another refresh

## Changelog

- prevent version control from entering repeated refresh loops while a user-version sync is still in progress
- make pending version-refresh state reset cleanly once a reload is about to happen

## Testing

- `node --check knackFunctions.js`